### PR TITLE
update for async v0.16

### DIFF
--- a/async-uri.opam
+++ b/async-uri.opam
@@ -12,9 +12,9 @@ depends: [
   "dune" {>= "1.11.4"}
   "uri" {>= "4.0.0"}
   "uri-sexp" {>= "4.0.0"}
-  "core" {>= "v0.15.0"}
-  "async" {>= "v0.15.0"}
-  "async_ssl" {>= "v0.15.0"}
+  "core" {>= "v0.16.1"}
+  "async" {>= "v0.16.0"}
+  "async_ssl" {>= "v0.16.0"}
 ]
 synopsis: "Open Async (TLS) TCP connections with Uri.t"
 description: """Simple wrapper to the Async's Tcp module to open

--- a/async-uri.opam
+++ b/async-uri.opam
@@ -12,9 +12,9 @@ depends: [
   "dune" {>= "1.11.4"}
   "uri" {>= "4.0.0"}
   "uri-sexp" {>= "4.0.0"}
-  "core" {>= "v0.14.0"}
-  "async" {>= "v0.14.0"}
-  "async_ssl" {>= "v0.14.0"}
+  "core" {>= "v0.15.0"}
+  "async" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
 ]
 synopsis: "Open Async (TLS) TCP connections with Uri.t"
 description: """Simple wrapper to the Async's Tcp module to open

--- a/src/async_uri.ml
+++ b/src/async_uri.ml
@@ -53,7 +53,6 @@ module T = struct
     Writer.close w >>= fun () -> Reader.close r
 
   let close_finished { r; _ } = Reader.close_finished r
-
   let is_closed { r; _ } = Reader.is_closed r
 end
 
@@ -97,7 +96,7 @@ let with_connection ?version ?options ?buffer_age_limit ?interrupt
           ssl_connect ?version ?options url r w >>= fun (ssl, _flushed, r, w) ->
           Monitor.protect
             (fun () -> f (create ~ssl s r w))
-            ~finally:(fun () -> Reader.close r >>= fun () -> Writer.close w) )
+            ~finally:(fun () -> Reader.close r >>= fun () -> Writer.close w))
 
 let listen_ssl ?version ?options ?name ?allowed_ciphers ?ca_file ?ca_path
     ?verify_modes ~crt_file ~key_file ?buffer_age_limit ?max_connections
@@ -117,10 +116,10 @@ let listen_ssl ?version ?options ?name ?allowed_ciphers ?ca_file ?ca_path
             ~crt_file ~key_file ?verify_modes ~ssl_to_net ~net_to_ssl
             ~app_to_ssl ~ssl_to_app ()
           |> Deferred.Or_error.ok_exn
-          >>= fun c -> f s c r w )
+          >>= fun c -> f s c r w)
         ~finally:(fun () ->
           Pipe.close ssl_to_net;
           Pipe.close_read net_to_ssl;
           Pipe.close_read app_to_ssl;
           Pipe.close_read client_read;
-          Reader.close r >>= fun () -> Writer.close w ) )
+          Reader.close r >>= fun () -> Writer.close w))

--- a/src/async_uri.mli
+++ b/src/async_uri.mli
@@ -14,15 +14,25 @@ val connect :
   ?version:Async_ssl.Version.t ->
   ?options:Async_ssl.Opt.t list ->
   ?socket:([ `Unconnected ], Socket.Address.Inet.t) Socket.t ->
-  (Uri.t -> t Deferred.t) Tcp.with_connect_options
+  ?buffer_age_limit:[ `At_most of Time_unix.Span.t | `Unlimited ] ->
+  ?interrupt:unit Deferred.t ->
+  ?reader_buffer_size:int ->
+  ?writer_buffer_size:int ->
+  ?timeout:Time_unix.Span.t ->
+  Uri.t -> t Deferred.t
 
 val with_connection :
   ?version:Async_ssl.Version.t ->
   ?options:Async_ssl.Opt.t list ->
-  (Uri.t -> (t -> 'a Deferred.t) -> 'a Deferred.t) Tcp.with_connect_options
+  ?buffer_age_limit:[ `At_most of Time_unix.Span.t | `Unlimited ] ->
+  ?interrupt:unit Deferred.t ->
+  ?reader_buffer_size:int ->
+  ?writer_buffer_size:int ->
+  ?timeout:Time_unix.Span.t ->
+  Uri.t -> (t -> 'a Deferred.t) -> 'a Deferred.t
 
 module Persistent :
-  Persistent_connection_kernel.S with type conn := t and type address = Uri.t
+  Persistent_connection_kernel.S with type conn := t
 
 val listen_ssl :
   ?version:Async_ssl.Version.t ->

--- a/src/async_uri.mli
+++ b/src/async_uri.mli
@@ -14,22 +14,22 @@ val connect :
   ?version:Async_ssl.Version.t ->
   ?options:Async_ssl.Opt.t list ->
   ?socket:([ `Unconnected ], Socket.Address.Inet.t) Socket.t ->
-  ?buffer_age_limit:[ `At_most of Time_unix.Span.t | `Unlimited ] ->
+  ?buffer_age_limit:[ `At_most of Time_float_unix.Span.t | `Unlimited ] ->
   ?interrupt:unit Deferred.t ->
   ?reader_buffer_size:int ->
   ?writer_buffer_size:int ->
-  ?timeout:Time_unix.Span.t ->
+  ?timeout:Time_float_unix.Span.t ->
   Uri.t ->
   t Deferred.t
 
 val with_connection :
   ?version:Async_ssl.Version.t ->
   ?options:Async_ssl.Opt.t list ->
-  ?buffer_age_limit:[ `At_most of Time_unix.Span.t | `Unlimited ] ->
+  ?buffer_age_limit:[ `At_most of Time_float_unix.Span.t | `Unlimited ] ->
   ?interrupt:unit Deferred.t ->
   ?reader_buffer_size:int ->
   ?writer_buffer_size:int ->
-  ?timeout:Time_unix.Span.t ->
+  ?timeout:Time_float_unix.Span.t ->
   Uri.t ->
   (t -> 'a Deferred.t) ->
   'a Deferred.t

--- a/src/async_uri.mli
+++ b/src/async_uri.mli
@@ -19,7 +19,8 @@ val connect :
   ?reader_buffer_size:int ->
   ?writer_buffer_size:int ->
   ?timeout:Time_unix.Span.t ->
-  Uri.t -> t Deferred.t
+  Uri.t ->
+  t Deferred.t
 
 val with_connection :
   ?version:Async_ssl.Version.t ->
@@ -29,10 +30,11 @@ val with_connection :
   ?reader_buffer_size:int ->
   ?writer_buffer_size:int ->
   ?timeout:Time_unix.Span.t ->
-  Uri.t -> (t -> 'a Deferred.t) -> 'a Deferred.t
+  Uri.t ->
+  (t -> 'a Deferred.t) ->
+  'a Deferred.t
 
-module Persistent :
-  Persistent_connection_kernel.S with type conn := t
+module Persistent : Persistent_connection_kernel.S with type conn := t
 
 val listen_ssl :
   ?version:Async_ssl.Version.t ->

--- a/src/dune
+++ b/src/dune
@@ -5,5 +5,6 @@
    uri-sexp
    uri.services
    core
+   core_unix.time_float_unix
    async
    async_ssl))


### PR DESCRIPTION
It seems like [update for async v0.15](https://github.com/vbmithr/async-uri/commit/f55df541b78b281029ff205dac4f3dcfa602e402) was somehow reverted in [mostly ocamlformat](https://github.com/vbmithr/async-uri/commit/a1118550f8348ac496861ca22bf87b0da20519d8) so it includes both.

The only change seems to be:

* Module `Time_unix` was replaced by `Time_float_unix`.
